### PR TITLE
Quick and dirty performance timer

### DIFF
--- a/src/FaceGenManager.cpp
+++ b/src/FaceGenManager.cpp
@@ -102,12 +102,12 @@ void FaceGenManager::InstallPerformanceTimers()
 }
 
 char FaceGenManager::PerformanceTimer_GetHeadModel(
-	RE::TESNPC* a_actor, void* a_arg2, void* a_arg3)
+	RE::TESNPC* a_actor, RE::BSTSmartPointer<RE::BSFaceGenNiNode>* a_result, void** a_arg3)
 {
-	logger::info("Getting head for NPC '{}' ({:8x}).", a_actor->fullName, a_actor->formID);
+	logger::info("Getting head for NPC '{}' ({:08x}).", a_actor->fullName, a_actor->formID);
 
 	auto begin = std::chrono::high_resolution_clock::now();
-	auto result = _GetHeadModel(a_actor, a_arg2, a_arg3);
+	auto result = _GetHeadModel(a_actor, a_result, a_arg3);
 	auto end = std::chrono::high_resolution_clock::now();
 
 	logger::info(

--- a/src/FaceGenManager.h
+++ b/src/FaceGenManager.h
@@ -5,9 +5,14 @@ class FaceGenManager
 public:
 	static void InstallFaceDiscolorationFix();
 	static void InstallIgnorePreprocessedFaceGen();
+	static void InstallPerformanceTimers();
 
 private:
 	FaceGenManager() = default;
 	static bool DataLoad_CheckRace(RE::TESNPC* a_actor);
 
+	static char PerformanceTimer_GetHeadModel(
+		RE::TESNPC* a_actor, void* a_arg2, void* a_arg3);
+
+	inline static REL::Relocation<decltype(PerformanceTimer_GetHeadModel)> _GetHeadModel;
 };

--- a/src/FaceGenManager.h
+++ b/src/FaceGenManager.h
@@ -12,7 +12,7 @@ private:
 	static bool DataLoad_CheckRace(RE::TESNPC* a_actor);
 
 	static char PerformanceTimer_GetHeadModel(
-		RE::TESNPC* a_actor, void* a_arg2, void* a_arg3);
+		RE::TESNPC* a_actor, RE::BSTSmartPointer<RE::BSFaceGenNiNode>* a_result, void** a_arg3);
 
 	inline static REL::Relocation<decltype(PerformanceTimer_GetHeadModel)> _GetHeadModel;
 };

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -12,6 +12,8 @@ namespace Hooks
 			{
 				FaceGenManager::InstallIgnorePreprocessedFaceGen();
 			}
+
+			FaceGenManager::InstallPerformanceTimers();
 		}
 	}
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,6 +54,7 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
 	logger::info("FacegenFixes loaded");
 
 	SKSE::Init(a_skse);
+	SKSE::AllocTrampoline(14);
 
 	Hooks::Install();
 


### PR DESCRIPTION
Preprocessed FaceGen:
```
src\main.cpp(31): [info] FacegenFixes v1.0.1.0
src\main.cpp(54): [info] FacegenFixes loaded
src\SKSE\Trampoline.cpp(56): [info] Default Trampoline => 0B / 28B (00.00%)
src\FaceGenManager.cpp(56): [info] Installed hooks for face discoloration fix
src\SKSE\Trampoline.cpp(56): [info] Default Trampoline => 14B / 28B (50.00%)
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Tilma the Haggard' (   13bb6).
src\FaceGenManager.cpp(122): [info] Finished in 156450µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Vignar Gray-Mane' (   13bb5).
src\FaceGenManager.cpp(122): [info] Finished in 69335µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Aela the Huntress' (   1a696).
src\FaceGenManager.cpp(122): [info] Finished in 202µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Brill' (   1a6a2).
src\FaceGenManager.cpp(122): [info] Finished in 187µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Skjor' (   1a690).
src\FaceGenManager.cpp(122): [info] Finished in 247µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Prisoner' (       7).
src\FaceGenManager.cpp(122): [info] Finished in 1196µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Athis' (   1a6d5).
src\FaceGenManager.cpp(122): [info] Finished in 274µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Njada Stonearm' (   1a6d9).
src\FaceGenManager.cpp(122): [info] Finished in 264µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Torvar' (   1a6db).
src\FaceGenManager.cpp(122): [info] Finished in 244µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Ria' (   1a6d7).
src\FaceGenManager.cpp(122): [info] Finished in 214µs.
```

Runtime FaceGen:
```
src\main.cpp(31): [info] FacegenFixes v1.0.1.0
src\main.cpp(54): [info] FacegenFixes loaded
src\SKSE\Trampoline.cpp(56): [info] Default Trampoline => 0B / 28B (00.00%)
src\FaceGenManager.cpp(56): [info] Installed hooks for face discoloration fix
src\SKSE\Trampoline.cpp(56): [info] Default Trampoline => 14B / 28B (50.00%)
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Tilma the Haggard' (   13bb6).
src\FaceGenManager.cpp(122): [info] Finished in 180390µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Skjor' (   1a690).
src\FaceGenManager.cpp(122): [info] Finished in 66196µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Aela the Huntress' (   1a696).
src\FaceGenManager.cpp(122): [info] Finished in 52155µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Vignar Gray-Mane' (   13bb5).
src\FaceGenManager.cpp(122): [info] Finished in 57711µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Brill' (   1a6a2).
src\FaceGenManager.cpp(122): [info] Finished in 2440µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Prisoner' (       7).
src\FaceGenManager.cpp(122): [info] Finished in 1285µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Athis' (   1a6d5).
src\FaceGenManager.cpp(122): [info] Finished in 45946µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Njada Stonearm' (   1a6d9).
src\FaceGenManager.cpp(122): [info] Finished in 67359µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Torvar' (   1a6db).
src\FaceGenManager.cpp(122): [info] Finished in 32294µs.
src\FaceGenManager.cpp(116): [info] Getting head for NPC 'Ria' (   1a6d7).
src\FaceGenManager.cpp(122): [info] Finished in 131423µs.
```